### PR TITLE
Add CLAM-style WSI dataset

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,32 @@ trainer.train(dataloader, epochs=10)
 torch.save(model.state_dict(), 'model.pth')
 ```
 
+## Loading CLAM-style WSI features
+
+If you already processed Whole Slide Images with
+[CLAM](https://github.com/mahmoodlab/CLAM) and stored the bags as `.pt` feature
+files plus optional `.h5` coordinate files, you can load them with
+`CLAMWSIDataset`:
+
+```python
+from torchmil.datasets import CLAMWSIDataset
+
+dataset = CLAMWSIDataset(
+    csv_path="dataset/slides.csv",          # slide metadata exported by CLAM
+    features_dir="dataset/pt_files",        # optional: one {slide_id}.pt per slide
+    coords_dir="dataset/h5_files",          # optional: one {slide_id}.h5 per slide
+    label_map={"normal": 0, "tumor": 1},   # map slide labels to integers
+    bag_keys=["X", "Y", "coords", "adj"],
+)
+
+bag = dataset[0]
+print(bag.keys())  # -> ['X', 'Y', 'coords', 'adj']
+```
+
+Set `use_h5_features=True` when the CLAM export only contains `.h5` files (the
+dataset will read both the features and coordinates from them). The adjacency
+matrix is built automatically whenever coordinates are available.
+
 ## Next steps
 
 You can take a look at the [examples](https://franblueee.github.io/torchmil/examples/) to see how to use **torchmil** in practice.

--- a/docs/api/datasets/clam_wsi_dataset.md
+++ b/docs/api/datasets/clam_wsi_dataset.md
@@ -1,0 +1,87 @@
+# CLAM WSI dataset
+
+The `CLAMWSIDataset` bridges pre-processed Whole Slide Image (WSI) bags generated
+with the [CLAM](https://github.com/mahmoodlab/CLAM) pipeline and the
+`ProcessedMILDataset` interface provided by **torchmil**. It understands the file
+layout used by CLAM (CSV metadata plus `.pt` features and optional `.h5`
+coordinate files) and returns bags that can be fed directly to MIL models.
+
+## Expected file structure
+
+```text
+dataset/
+├── slides.csv            # slide-level metadata with labels
+├── pt_files/             # optional; one `{slide_id}.pt` file per slide
+│   ├── slide_a.pt
+│   └── slide_b.pt
+└── h5_files/             # optional; one `{slide_id}.h5` file per slide
+    ├── slide_a.h5
+    └── slide_b.h5
+```
+
+- ``slides.csv`` must contain at least two columns: one with the slide
+  identifiers (``slide_id`` by default) and another one with the labels
+  (``label`` by default). Extra columns are preserved in
+  ``CLAMWSIDataset.slide_metadata`` for downstream usage.
+- ``pt_files`` should contain the CLAM features exported as PyTorch tensors. The
+  dataset can also read dictionaries (``{"features": tensor}``) or sequences;
+  use ``pt_feature_key``/``pt_feature_index`` when you need to select a
+  particular value.
+- ``h5_files`` should provide the instance coordinates in a dataset named
+  ``coords`` by default. When ``use_h5_features=True`` the features are read from
+  the ``features`` dataset within the same file.
+
+Provide ``features_dir`` when you want to load the bags from the `.pt` files,
+``coords_dir`` when the coordinates (or the adjacency matrix) are required, and
+both directories when you need features and coordinates simultaneously.
+
+## Quick start
+
+```python
+from torchmil.datasets import CLAMWSIDataset
+
+# Load CLAM features stored as .pt tensors and the coordinates from .h5 files
+clam_dataset = CLAMWSIDataset(
+    csv_path="dataset/slides.csv",
+    features_dir="dataset/pt_files",
+    coords_dir="dataset/h5_files",
+    label_map={"normal": 0, "tumor": 1},  # map CSV labels to integers
+    bag_keys=["X", "Y", "coords", "adj"],  # request features, labels, coords, and adjacency
+)
+
+bag = clam_dataset[0]
+print(bag.keys())  # -> ['X', 'Y', 'coords', 'adj']
+print(bag["X"].shape)  # instance features
+print(bag["Y"])        # slide-level label
+```
+
+Use ``wsi_names`` to focus on a subset of slides, and provide a custom
+``label_map`` when your CSV labels are strings. Setting ``bag_keys`` controls
+which tensors are returned for each bag. When the coordinates are available, the
+adjacency matrix is built automatically using the Euclidean distances between
+patches (see the parameters ``dist_thr``, ``adj_with_dist`` and ``norm_adj`` for
+additional control).
+
+### Loading features from `.h5`
+
+If your CLAM export only contains `.h5` files, enable ``use_h5_features`` and
+omit ``features_dir``:
+
+```python
+clam_dataset = CLAMWSIDataset(
+    csv_path="dataset/slides.csv",
+    coords_dir="dataset/h5_files",
+    use_h5_features=True,
+    bag_keys=["X", "Y"],
+)
+```
+
+The dataset will read both the features and the coordinates from each HDF5 file
+(using the datasets named ``features`` and ``coords`` by default).
+
+## API reference
+
+::: torchmil.datasets.CLAMWSIDataset
+    options:
+        members:
+            - __init__

--- a/docs/api/datasets/index.md
+++ b/docs/api/datasets/index.md
@@ -11,6 +11,7 @@ This list is constantly updated with new datasets and examples, feel free to con
 - [Toy Dataset](toy_dataset.md)
 - [CT Scan Dataset](ctscan_dataset.md)
 - [WSI Dataset](wsi_dataset.md)
+- [CLAM WSI Dataset](clam_wsi_dataset.md)
 - [Binary classification Dataset](binary_classification_dataset.md)
 - [Camelyon16 MIL Dataset](camelyon16mil_dataset.md)
 - [PANDA MIL Dataset](pandamil_dataset.md)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,9 @@ dependencies = [
   "einops",
   "scipy",
   "tqdm",
-  "numpy"
+  "numpy",
+  "pandas",
+  "h5py"
 ]
 description = "Deep Multiple Instance Learning library for Pytorch"
 keywords = [

--- a/tests/datasets/test_clam_wsi_dataset.py
+++ b/tests/datasets/test_clam_wsi_dataset.py
@@ -1,0 +1,105 @@
+import pytest
+
+h5py = pytest.importorskip("h5py")
+
+import numpy as np
+import pandas as pd
+import torch
+
+from torchmil.datasets import CLAMWSIDataset
+
+
+@pytest.fixture
+def clam_wsi_setup(tmp_path):
+    features_dir = tmp_path / "pt_files"
+    coords_dir = tmp_path / "h5_files"
+    features_dir.mkdir()
+    coords_dir.mkdir()
+
+    slide_ids = ["slide_0", "slide_1"]
+    labels = ["tumor", "normal"]
+
+    pt_features = {}
+    h5_features = {}
+    coords = {}
+
+    for idx, slide in enumerate(slide_ids):
+        feat = torch.randn(4 + idx, 3)
+        pt_features[slide] = feat.detach().cpu().numpy()
+        torch.save(feat, features_dir / f"{slide}.pt")
+
+        coords_arr = np.random.randint(0, 64, size=(4 + idx, 2))
+        coords[slide] = coords_arr
+        h5_feat = np.full((4 + idx, 3), fill_value=idx, dtype=np.float32)
+        h5_features[slide] = h5_feat
+        with h5py.File(coords_dir / f"{slide}.h5", "w") as handle:
+            handle.create_dataset("coords", data=coords_arr)
+            handle.create_dataset("features", data=h5_feat)
+
+    csv_path = tmp_path / "slides.csv"
+    pd.DataFrame({"slide_id": slide_ids, "label": labels}).to_csv(
+        csv_path, index=False
+    )
+
+    return {
+        "csv_path": str(csv_path),
+        "features_dir": str(features_dir),
+        "coords_dir": str(coords_dir),
+        "slide_ids": slide_ids,
+        "labels": labels,
+        "pt_features": pt_features,
+        "h5_features": h5_features,
+        "coords": coords,
+    }
+
+
+def test_clam_wsi_dataset_pt_features(clam_wsi_setup):
+    dataset = CLAMWSIDataset(
+        csv_path=clam_wsi_setup["csv_path"],
+        features_dir=clam_wsi_setup["features_dir"],
+        coords_dir=clam_wsi_setup["coords_dir"],
+        label_map={"normal": 0, "tumor": 1},
+        bag_keys=["X", "Y", "coords"],
+    )
+
+    assert len(dataset) == len(clam_wsi_setup["slide_ids"])
+
+    bag = dataset[0]
+    slide_id = clam_wsi_setup["slide_ids"][0]
+    np.testing.assert_allclose(
+        bag["X"].numpy(), clam_wsi_setup["pt_features"][slide_id], rtol=1e-6
+    )
+    assert bag["Y"].item() == 1
+    np.testing.assert_array_equal(
+        bag["coords"].numpy(), clam_wsi_setup["coords"][slide_id]
+    )
+
+
+def test_clam_wsi_dataset_h5_features(clam_wsi_setup):
+    dataset = CLAMWSIDataset(
+        csv_path=clam_wsi_setup["csv_path"],
+        coords_dir=clam_wsi_setup["coords_dir"],
+        use_h5_features=True,
+        bag_keys=["X", "Y", "coords"],
+    )
+
+    bag = dataset[1]
+    slide_id = clam_wsi_setup["slide_ids"][1]
+    np.testing.assert_allclose(
+        bag["X"].numpy(), clam_wsi_setup["h5_features"][slide_id]
+    )
+    assert bag["Y"].item() in {0, 1}
+
+
+def test_clam_wsi_dataset_adjacency(clam_wsi_setup):
+    dataset = CLAMWSIDataset(
+        csv_path=clam_wsi_setup["csv_path"],
+        features_dir=clam_wsi_setup["features_dir"],
+        coords_dir=clam_wsi_setup["coords_dir"],
+        bag_keys=["X", "Y", "coords", "adj"],
+    )
+
+    bag = dataset[0]
+    assert "adj" in bag
+    assert bag["adj"].is_sparse
+    assert bag["adj"].shape[0] == bag["X"].shape[0]

--- a/torchmil/datasets/__init__.py
+++ b/torchmil/datasets/__init__.py
@@ -3,6 +3,7 @@ from .binary_classification_dataset import (
     BinaryClassificationDataset as BinaryClassificationDataset,
 )
 from .camelyon16mil_dataset import CAMELYON16MILDataset as CAMELYON16MILDataset
+from .clam_wsi_dataset import CLAMWSIDataset as CLAMWSIDataset
 from .pandamil_dataset import PANDAMILDataset as PANDAMILDataset
 from .rsnamil_dataset import RSNAMILDataset as RSNAMILDataset
 

--- a/torchmil/datasets/clam_wsi_dataset.py
+++ b/torchmil/datasets/clam_wsi_dataset.py
@@ -1,0 +1,303 @@
+from __future__ import annotations
+
+import os
+from typing import Iterable, Optional
+
+import numpy as np
+import pandas as pd
+import torch
+
+from .processed_mil_dataset import ProcessedMILDataset
+
+try:  # pragma: no cover - simple import guard
+    import h5py
+except ModuleNotFoundError as import_error:  # pragma: no cover - handled lazily
+    h5py = None
+    _H5PY_IMPORT_ERROR = import_error
+else:  # pragma: no cover - executed when dependency available
+    _H5PY_IMPORT_ERROR = None
+
+
+class CLAMWSIDataset(ProcessedMILDataset):
+    r"""Dataset for CLAM-style processed WSIs.
+
+    This dataset loads MIL bags that have been pre-processed with the
+    [CLAM](https://github.com/mahmoodlab/CLAM) pipeline. CLAM stores the bag
+    features as ``.pt`` files and the spatial coordinates (and optionally the
+    features) as ``.h5`` files, while the metadata (e.g., the slide level
+    labels) is tracked inside a CSV file. This class bridges that file layout
+    with :class:`~torchmil.datasets.ProcessedMILDataset` so that the bags can be
+    readily consumed by TorchMIL models.
+
+    Parameters
+    ----------
+    csv_path:
+        Path to the CSV file containing the slide metadata. The CSV must
+        contain at least two columns with the slide identifiers and the
+        corresponding labels.
+    features_dir:
+        Directory that stores the ``.pt`` feature files produced by CLAM.
+        File names are expected to follow ``{slide_id}.pt``. Provide ``None``
+        when the bag features should be read from the ``.h5`` files
+        (``use_h5_features=True``).
+    coords_dir:
+        Directory that stores the ``.h5`` files with the instance coordinates
+        (and optionally the features). File names are expected to follow
+        ``{slide_id}.h5``. It must be provided when ``"coords"`` or ``"adj"``
+        are requested in ``bag_keys`` or when ``use_h5_features=True``.
+    slide_id_col:
+        Name of the column in ``csv_path`` that identifies the slides.
+    label_col:
+        Name of the column in ``csv_path`` that stores the slide labels.
+    wsi_names:
+        Optional list with the subset of slide identifiers to load. When
+        provided, only those slides are kept.
+    label_map:
+        Optional mapping from label values in ``label_col`` to integers. When
+        omitted the labels are sorted and mapped to ``range(n_classes)``.
+    bag_keys:
+        Keys that should be returned for each bag. They follow the same
+        semantics as :class:`~torchmil.datasets.ProcessedMILDataset`. By
+        default the dataset returns the features (``"X"``), the slide label
+        (``"Y"``) and the coordinates (``"coords"``). When ``coords_dir`` is
+        ``None`` the keys related to coordinates (``"coords"`` and ``"adj"``)
+        are automatically discarded.
+    use_h5_features:
+        If ``True``, the features are loaded from the ``.h5`` files instead of
+        the ``.pt`` files. In that case ``coords_dir`` must be provided because
+        the features are expected to live in the same file as the coordinates.
+    pt_feature_key:
+        Optional key that identifies the tensor containing the features when a
+        ``.pt`` file stores a dictionary. When ``None`` a few common keys are
+        tried (``"features"``, ``"feats"`` and ``"data"``).
+    pt_feature_index:
+        Index that should be used when the ``.pt`` file contains a list or a
+        tuple and the features need to be selected from it. The default selects
+        the first element.
+    h5_feature_key:
+        Dataset name inside the ``.h5`` files that stores the instance
+        features. Only used when ``use_h5_features=True``.
+    h5_coords_key:
+        Dataset name inside the ``.h5`` files that stores the instance
+        coordinates.
+    dist_thr, adj_with_dist, norm_adj, load_at_init:
+        See :class:`~torchmil.datasets.ProcessedMILDataset` for a description of
+        these parameters.
+    """
+
+    def __init__(
+        self,
+        csv_path: str,
+        features_dir: Optional[str] = None,
+        coords_dir: Optional[str] = None,
+        slide_id_col: str = "slide_id",
+        label_col: str = "label",
+        wsi_names: Optional[Iterable[str]] = None,
+        label_map: Optional[dict] = None,
+        bag_keys: Optional[list[str]] = None,
+        use_h5_features: bool = False,
+        pt_feature_key: Optional[str] = None,
+        pt_feature_index: int = 0,
+        h5_feature_key: str = "features",
+        h5_coords_key: str = "coords",
+        dist_thr: Optional[float] = None,
+        adj_with_dist: bool = False,
+        norm_adj: bool = True,
+        load_at_init: bool = False,
+    ) -> None:
+        self.csv_path = csv_path
+        self.slide_id_col = slide_id_col
+        self.label_col = label_col
+        self.use_h5_features = use_h5_features
+        self.pt_feature_key = pt_feature_key
+        self.pt_feature_index = pt_feature_index
+        self.h5_feature_key = h5_feature_key
+        self.h5_coords_key = h5_coords_key
+        self.pt_features_path = features_dir
+        self.coords_path = coords_dir
+
+        if bag_keys is None:
+            bag_keys = ["X", "Y", "coords"]
+        else:
+            bag_keys = list(dict.fromkeys(bag_keys))
+
+        if coords_dir is None:
+            bag_keys = [key for key in bag_keys if key not in {"coords", "adj"}]
+
+        if (coords_dir is not None or use_h5_features) and h5py is None:
+            raise ImportError(
+                "h5py is required to handle '.h5' files. Please install it to use "
+                "CLAMWSIDataset with coordinates or HDF5 features."
+            ) from _H5PY_IMPORT_ERROR
+
+        if "X" in bag_keys and not use_h5_features and features_dir is None:
+            raise ValueError(
+                "features_dir must be provided when 'X' is requested and use_h5_features is False"
+            )
+
+        if use_h5_features and coords_dir is None:
+            raise ValueError(
+                "coords_dir must be provided when use_h5_features=True because features are read from the h5 files"
+            )
+
+        if not os.path.exists(csv_path):
+            raise FileNotFoundError(f"CSV file not found: {csv_path}")
+
+        slide_df = pd.read_csv(csv_path)
+        if slide_id_col not in slide_df.columns:
+            raise ValueError(
+                f"Column '{slide_id_col}' not found in the CSV file. Available columns: {slide_df.columns.tolist()}"
+            )
+        if label_col not in slide_df.columns:
+            raise ValueError(
+                f"Column '{label_col}' not found in the CSV file. Available columns: {slide_df.columns.tolist()}"
+            )
+
+        slide_df = slide_df[[slide_id_col, label_col]].dropna()
+        slide_df[slide_id_col] = slide_df[slide_id_col].astype(str)
+
+        if wsi_names is not None:
+            wsi_names = [str(name) for name in wsi_names]
+            missing = set(wsi_names) - set(slide_df[slide_id_col])
+            if missing:
+                raise ValueError(
+                    f"The following slide identifiers were not found in the CSV file: {sorted(missing)}"
+                )
+            slide_df = slide_df[slide_df[slide_id_col].isin(wsi_names)]
+
+        if slide_df.empty:
+            raise ValueError("No slides available after applying the provided filters")
+
+        if label_map is None:
+            unique_labels = sorted(slide_df[label_col].unique())
+            label_map = {label: idx for idx, label in enumerate(unique_labels)}
+        else:
+            missing_labels = set(slide_df[label_col].unique()) - set(label_map.keys())
+            if missing_labels:
+                raise ValueError(
+                    "label_map is missing values for: " + ", ".join(map(str, sorted(missing_labels)))
+                )
+
+        slide_df["__label_id"] = slide_df[label_col].map(label_map)
+        if slide_df["__label_id"].isnull().any():
+            raise ValueError("label_map produced NaN values; please double-check it")
+
+        bag_names = slide_df[slide_id_col].tolist()
+
+        if not bag_names:
+            raise ValueError("No slide identifiers found")
+
+        if "X" in bag_keys and not use_h5_features:
+            missing_features = [
+                name
+                for name in bag_names
+                if not os.path.exists(os.path.join(features_dir, f"{name}.pt"))
+            ]
+            if missing_features:
+                raise FileNotFoundError(
+                    "The following feature files were not found: "
+                    + ", ".join(sorted(missing_features))
+                )
+
+        if coords_dir is not None:
+            missing_coords = [
+                name
+                for name in bag_names
+                if not os.path.exists(os.path.join(coords_dir, f"{name}.h5"))
+            ]
+            if missing_coords:
+                raise FileNotFoundError(
+                    "The following coordinate files were not found: "
+                    + ", ".join(sorted(missing_coords))
+                )
+
+        self.labels_dict = dict(zip(bag_names, slide_df["__label_id"].astype(int)))
+        self.label_map = label_map
+        self.slide_metadata = slide_df.drop(columns="__label_id").reset_index(drop=True)
+
+        if dist_thr is None:
+            dist_thr = float(np.sqrt(2.0))
+
+        features_path = coords_dir if use_h5_features else features_dir
+        super().__init__(
+            features_path=features_path,
+            labels_path=csv_path,
+            coords_path=coords_dir,
+            bag_names=bag_names,
+            bag_keys=bag_keys,
+            dist_thr=dist_thr,
+            adj_with_dist=adj_with_dist,
+            norm_adj=norm_adj,
+            load_at_init=load_at_init,
+        )
+
+    def _load_features(self, name: str) -> np.ndarray:
+        if self.use_h5_features:
+            h5_file = os.path.join(self.coords_path, f"{name}.h5")
+            with h5py.File(h5_file, "r") as handle:
+                if self.h5_feature_key not in handle:
+                    raise KeyError(
+                        f"Dataset '{self.h5_feature_key}' not found inside {h5_file}"
+                    )
+                features = handle[self.h5_feature_key][:]
+        else:
+            feature_file = os.path.join(self.pt_features_path, f"{name}.pt")
+            data = torch.load(feature_file)
+            features = self._extract_pt_features(data, feature_file)
+
+        features = np.asarray(features)
+        return features
+
+    def _extract_pt_features(self, data, feature_file: str) -> np.ndarray:
+        if isinstance(data, torch.Tensor):
+            return data.detach().cpu().numpy()
+        if isinstance(data, np.ndarray):
+            return data
+        if isinstance(data, (list, tuple)):
+            if len(data) <= self.pt_feature_index:
+                raise IndexError(
+                    f"Cannot extract index {self.pt_feature_index} from {feature_file}; "
+                    f"it only contains {len(data)} elements"
+                )
+            selected = data[self.pt_feature_index]
+            if isinstance(selected, torch.Tensor):
+                return selected.detach().cpu().numpy()
+            return np.asarray(selected)
+        if isinstance(data, dict):
+            if self.pt_feature_key is not None:
+                if self.pt_feature_key not in data:
+                    raise KeyError(
+                        f"Key '{self.pt_feature_key}' not found in {feature_file}"
+                    )
+                value = data[self.pt_feature_key]
+            else:
+                for candidate in ("features", "feats", "data"):
+                    if candidate in data:
+                        value = data[candidate]
+                        break
+                else:
+                    raise KeyError(
+                        f"Could not infer the key containing the features in {feature_file}. "
+                        "Please provide 'pt_feature_key' explicitly."
+                    )
+            if isinstance(value, torch.Tensor):
+                return value.detach().cpu().numpy()
+            return np.asarray(value)
+        return np.asarray(data)
+
+    def _load_labels(self, name: str) -> np.ndarray:
+        if name not in self.labels_dict:
+            raise KeyError(f"Label for slide '{name}' not found")
+        return np.array(self.labels_dict[name], dtype=np.int64)
+
+    def _load_coords(self, name: str) -> Optional[np.ndarray]:
+        if self.coords_path is None:
+            return None
+        h5_file = os.path.join(self.coords_path, f"{name}.h5")
+        with h5py.File(h5_file, "r") as handle:
+            if self.h5_coords_key not in handle:
+                raise KeyError(
+                    f"Dataset '{self.h5_coords_key}' not found inside {h5_file}"
+                )
+            coords = handle[self.h5_coords_key][:]
+        return coords


### PR DESCRIPTION
## Summary
- add a `CLAMWSIDataset` that can ingest CLAM-style CSV/`.pt`/`.h5` slide artifacts
- expose the new dataset through the public datasets module and exercise it with unit tests
- include pandas and h5py as core dependencies so the loader can access the metadata and HDF5 files
- document how to configure and use `CLAMWSIDataset` from the README and dataset API docs

## Testing
- pytest tests/datasets/test_clam_wsi_dataset.py *(skipped: h5py unavailable in the environment)*
- PYTHONPATH=. pytest tests/datasets/test_wsi_dataset.py

------
https://chatgpt.com/codex/tasks/task_e_68cc53c04ea08330aed10d34ed9a79a6